### PR TITLE
Pull route definition out of startup callback

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,10 +1,8 @@
-Meteor.startup(function() {
-  Router.route("/shared-auth-frame", {
-    name: "shared-auth-frame",
-    template: 'sharedAuthFrame',
-    layoutTemplate: 'emptyLayout',
-    waitOn: function() {
-      return {ready: function() { return !Meteor.loggingIn(); }}
-    }
-  });
+Router.route("/shared-auth-frame", {
+  name: "shared-auth-frame",
+  template: 'sharedAuthFrame',
+  layoutTemplate: 'emptyLayout',
+  waitOn: function() {
+    return {ready: function() { return !Meteor.loggingIn(); }}
+  }
 });


### PR DESCRIPTION
Deferring the shared-auth-frame route declaration until after startup can cause the route to be ignored if a catch-all route is being used by the application:

```
Router.route("/(.*)", { ... });
```

You could argue that it's better to not use catch-alls, and use notFoundTemplate instead, some packages assume that all routes will be named (manuelschoebel:ms-seo), and there is no reason (that I can see) to defer the shared-auth-frame setup until after startup.
